### PR TITLE
Fix r_vars indexing bug

### DIFF
--- a/src/bendersx_engine/algorithm.py
+++ b/src/bendersx_engine/algorithm.py
@@ -37,8 +37,8 @@ def benders_decomposition(
             blocks_metadata, m0, total_r, all_cuts, config
         )
         args_list = []
-        for block_id, start, end in blocks_metadata:
-            r_i = r_vars[0]
+        for idx, (block_id, start, end) in enumerate(blocks_metadata):
+            r_i = r_vars[idx]
             args_list.append(
                 (
                     block_id,


### PR DESCRIPTION
## Summary
- use block-specific `r_vars` entry when building subproblem arguments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b065da2c832fa64d2350661f66a7