### PR TITLE
Add planwirtschaft problem type

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository contains a small Python implementation demonstrating the core st
 * **Examples and Tests** – a CLI entry point (`python -m bendersx_engine.cli`) and a small pytest suite.
 * **Early Stopping** – iterations halt once the solution change drops below a configurable tolerance.
 * **Adaptive Partitioning** – block sizes adjust according to the dual gap to better handle large planning models.
+* **Planned Economy Support** – generate matrices for `planwirtschaft` style input-output systems using the existing helpers.
 
 The implementation is not intended for production use. It omits many optimizations and contains simplified placeholders.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,4 +7,6 @@ The solver stops early when successive iterates change less than the
 
 The `partitioning` module splits blocks adaptively based on the dual gap. This
 helps keep workloads balanced for large-scale planning models such as
-Leontief-style input-output systems.
+Leontief-style input-output systems. The same routine can be used for
+"planwirtschaft" problems by specifying `problem_type="planwirtschaft"` when
+generating matrices.

--- a/src/bendersx_engine/matrix_generation.py
+++ b/src/bendersx_engine/matrix_generation.py
@@ -29,7 +29,7 @@ def generate_sparse_matrices(
         config = BendersConfig()
 
     A = _random_matrix(n, n, sparsity)
-    if problem_type == "leontief":
+    if problem_type in {"leontief", "planwirtschaft"}:
         diag_vals = [0.1 + 0.8 * random.random() for _ in range(n)]
         A.setdiag(diag_vals)
 

--- a/tests/test_matrix_generation.py
+++ b/tests/test_matrix_generation.py
@@ -5,3 +5,10 @@ def test_matrix_shapes():
     A, B = generate_sparse_matrices(10, 3)
     assert A.shape[0] == 10
     assert B.shape[0] == 3
+
+
+def test_planwirtschaft_problem_type():
+    A, _ = generate_sparse_matrices(5, 2, problem_type="planwirtschaft")
+    assert A.shape[0] == 5
+    diag_vals = [A.data[i][i] for i in range(5)]
+    assert all(v > 0 for v in diag_vals)


### PR DESCRIPTION
## Summary
- add `planwirtschaft` mode to `generate_sparse_matrices`
- document the new feature and reference planned economy models
- test that planwirtschaft matrix generation works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b932f7e4832f8fcb851ec24adda4