### PR TITLE
Improve planwirtschaft matrix generation

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,4 +9,6 @@ The `partitioning` module splits blocks adaptively based on the dual gap. This
 helps keep workloads balanced for large-scale planning models such as
 Leontief-style input-output systems. The same routine can be used for
 "planwirtschaft" problems by specifying `problem_type="planwirtschaft"` when
-generating matrices.
+generating matrices. In this mode the matrix generator now normalizes column
+sums to stay below one and ensures the demand matrix contains at least one
+non-zero entry per row.

--- a/src/bendersx_engine/matrix_generation.py
+++ b/src/bendersx_engine/matrix_generation.py
@@ -30,8 +30,17 @@ def generate_sparse_matrices(
 
     A = _random_matrix(n, n, sparsity)
     if problem_type in {"leontief", "planwirtschaft"}:
-        diag_vals = [0.1 + 0.8 * random.random() for _ in range(n)]
+        diag_vals = [0.2 + 0.7 * random.random() for _ in range(n)]
         A.setdiag(diag_vals)
+
+        # Ensure column sums remain below one as in classical
+        # input-output models. Scale columns exceeding the threshold.
+        for j in range(n):
+            col_sum = sum(A.data[i][j] for i in range(n))
+            if col_sum >= 0.95:
+                factor = 0.95 / col_sum
+                for i in range(n):
+                    A.data[i][j] *= factor
 
     rho = sparse_norm_optimized([v for row in A.data for v in row])
     if rho > 0:
@@ -40,5 +49,17 @@ def generate_sparse_matrices(
             for j in range(n):
                 A.data[i][j] *= scale
 
-    B = _random_matrix(m0, n, sparsity * 2)
+    if problem_type == "planwirtschaft":
+        data = []
+        num_entries = max(1, int(n * sparsity))
+        for _ in range(m0):
+            row = [0.0] * n
+            cols = random.sample(range(n), num_entries)
+            for j in cols:
+                row[j] = random.random()
+            data.append(row)
+        B = SimpleMatrix(data)
+    else:
+        B = _random_matrix(m0, n, sparsity * 2)
+
     return A, B

--- a/tests/test_matrix_generation.py
+++ b/tests/test_matrix_generation.py
@@ -8,7 +8,16 @@ def test_matrix_shapes():
 
 
 def test_planwirtschaft_problem_type():
-    A, _ = generate_sparse_matrices(5, 2, problem_type="planwirtschaft")
+    A, B = generate_sparse_matrices(5, 2, problem_type="planwirtschaft")
     assert A.shape[0] == 5
     diag_vals = [A.data[i][i] for i in range(5)]
     assert all(v > 0 for v in diag_vals)
+
+    # Column sums should remain below one for input-output models
+    for j in range(5):
+        col_sum = sum(A.data[i][j] for i in range(5))
+        assert col_sum < 0.96
+
+    # Each row of B should have at least one non-zero entry
+    for row in B.data:
+        assert any(val != 0 for val in row)


### PR DESCRIPTION
## Summary
- normalize column sums in planwirtschaft matrix generation
- generate sparse demand matrix with at least one non-zero per row
- document new behavior in usage guide
- test planwirtschaft matrix generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bd6de16c832fa9cd441381fe5efe