### PR TITLE
Extend planwirtschaft features

### DIFF
--- a/src/bendersx_engine/subproblem.py
+++ b/src/bendersx_engine/subproblem.py
@@ -53,11 +53,13 @@ def solve_subproblem_worker(args) -> Tuple[str, float, list, list, list, tuple |
 
     obj = sum(x_block)
     if inp.config.matrix_gen_params.get("planwirtschaft_objective"):
-        penalty_factor = inp.config.matrix_gen_params.get("underproduction_penalty", 1.0)
+        under_penalty = inp.config.matrix_gen_params.get("underproduction_penalty", 1.0)
+        over_penalty = inp.config.matrix_gen_params.get("overproduction_penalty", 0.0)
         planned = sum(inp.r_i_assigned)
         produced = sum(x_block)
-        deviation = max(0.0, planned - produced)
-        obj = produced - penalty_factor * deviation
+        under_dev = max(0.0, planned - produced)
+        over_dev = max(0.0, produced - planned)
+        obj = produced - under_penalty * under_dev - over_penalty * over_dev
     pi_i = [0.5 for _ in inp.r_i_assigned]
     mu_iT_d_value = obj - sum(pi_i[j] * inp.r_i_assigned[j] for j in range(len(pi_i)))
     cut = make_opt_cut(inp.block_id, pi_i, mu_iT_d_value)

--- a/tests/test_matrix_generation.py
+++ b/tests/test_matrix_generation.py
@@ -1,4 +1,5 @@
 from bendersx_engine.matrix_generation import generate_sparse_matrices
+from bendersx_engine import BendersConfig
 
 
 def test_matrix_shapes():
@@ -21,3 +22,14 @@ def test_planwirtschaft_problem_type():
     # Each row of B should have at least one non-zero entry
     for row in B.data:
         assert any(val != 0 for val in row)
+
+
+def test_planwirtschaft_row_targets_and_limits():
+    cfg = BendersConfig(verbose=False, matrix_gen_params={
+        "B_row_targets": {0: {1: 0.5}},
+        "A_column_limits": {0: 0.1},
+    })
+    A, B = generate_sparse_matrices(3, 2, problem_type="planwirtschaft", config=cfg)
+    assert B.data[0][1] == 0.5
+    col_sum = sum(A.data[i][0] for i in range(3))
+    assert col_sum <= 0.1 + 1e-9

--- a/tests/test_subproblem.py
+++ b/tests/test_subproblem.py
@@ -25,3 +25,29 @@ def test_subproblem_worker_runs():
     res = solve_subproblem_worker(args)
     cleanup_shared_memory()
     assert res[0] == "b0"
+
+
+def test_overproduction_penalty():
+    cfg = BendersConfig(
+        verbose=False,
+        matrix_gen_params={"planwirtschaft_objective": True, "overproduction_penalty": 0.5},
+    )
+    A = sp.identity(2, format="csr")
+    B = sp.csr_matrix(np.ones((1, 2)))
+    A_meta = csr_to_shared("A", A)
+    B_meta = csr_to_shared("B", B)
+    args = (
+        "b0",
+        0,
+        2,
+        A_meta,
+        B_meta,
+        np.zeros(2),
+        np.zeros(2),
+        np.ones(1),
+        cfg.__dict__,
+    )
+    block_id, obj, *_ = solve_subproblem_worker(args)
+    cleanup_shared_memory()
+    assert block_id == "b0"
+    assert obj < 2.0


### PR DESCRIPTION
## Summary
- expand generation of planwirtschaft matrices with quota and resource limit parameters
- support penalties on overproduction in the subproblem objective
- add tests for planwirtschaft matrix quotas and penalties

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840da7a28c8832faa4b578c13a227ab