### PR TITLE
Improve planwirtschaft allocation and objective

### DIFF
--- a/src/bendersx_engine/config.py
+++ b/src/bendersx_engine/config.py
@@ -33,6 +33,8 @@ class PlanwirtschaftParams:
     tiered_overproduction_penalties: List[tuple] | None = None
     production_bonus: float = 0.0
     priority_sector_bonus_factor: float = 1.0
+    societal_bonuses: Dict[int, float] | None = None
+    min_block_allocations: Dict[int, float] | None = None
 
     def to_dict(self) -> Dict:
         return {k: getattr(self, k) for k in self.__dataclass_fields__}

--- a/src/bendersx_engine/master.py
+++ b/src/bendersx_engine/master.py
@@ -23,5 +23,33 @@ def solve_master_problem(blocks_metadata, m0, total_r, cuts, config):
         [total_r[j] * weights[idx] / sum_weights for j in range(m0)] for idx in range(b)
     ]
 
+    min_levels = config.matrix_gen_params.get("min_block_allocations", {})
+    for j in range(m0):
+        min_reqs = [min_levels.get(i, 0.0) * total_r[j] for i in range(b)]
+        sum_min = sum(min_reqs)
+        if sum_min >= total_r[j]:
+            for i in range(b):
+                share = min_reqs[i] / sum_min if sum_min > 0 else 1.0 / b
+                r_vars[i][j] = total_r[j] * share
+            continue
+
+        for i in range(b):
+            if min_reqs[i] > r_vars[i][j]:
+                r_vars[i][j] = min_reqs[i]
+        current = sum(r_vars[i][j] for i in range(b))
+        if current > total_r[j]:
+            excess = current - total_r[j]
+            adjustable = [i for i in range(b) if r_vars[i][j] > min_reqs[i]]
+            total_adj = sum(r_vars[i][j] - min_reqs[i] for i in adjustable)
+            for i in adjustable:
+                reducible = r_vars[i][j] - min_reqs[i]
+                reduction = excess * (reducible / total_adj) if total_adj else 0
+                r_vars[i][j] -= reduction
+        else:
+            remaining = total_r[j] - current
+            weight_sum = sum(weights)
+            for i in range(b):
+                r_vars[i][j] += remaining * (weights[i] / weight_sum if weight_sum else 1.0 / b)
+
     theta = [0.0 for _ in range(b)]
     return r_vars, theta

--- a/src/bendersx_engine/matrix_generation.py
+++ b/src/bendersx_engine/matrix_generation.py
@@ -109,6 +109,18 @@ def _apply_planwirtschaft_modifiers(A: SimpleMatrix, B: SimpleMatrix, params: di
             if 0 <= idx < A.shape[0]:
                 A.data[idx] = [val * tech_factor for val in A.data[idx]]
 
+        other_rows = [i for i in range(A.shape[0]) if i not in priority_sectors]
+        if other_rows:
+            target_avg = sum(sum(A.data[i]) for i in other_rows) / (
+                len(other_rows) * A.shape[1]
+            )
+            for idx in priority_sectors:
+                if 0 <= idx < A.shape[0]:
+                    row_avg = sum(A.data[idx]) / A.shape[1]
+                    if row_avg > target_avg and row_avg > 0:
+                        scale = target_avg / row_avg
+                        A.data[idx] = [val * scale for val in A.data[idx]]
+
     capacity_limits = params.get("sector_capacity_limits")
     if isinstance(capacity_limits, dict):
         for idx, limit in capacity_limits.items():

--- a/src/bendersx_engine/subproblem.py
+++ b/src/bendersx_engine/subproblem.py
@@ -81,6 +81,7 @@ def solve_subproblem_worker(args) -> Tuple[str, float, list, list, list, tuple |
         prod_bonus = inp.config.matrix_gen_params.get("production_bonus", 0.0)
         bonus_factor = inp.config.matrix_gen_params.get("priority_sector_bonus_factor", 1.0)
         priority = set(inp.config.matrix_gen_params.get("priority_sectors", []))
+        societal_bonuses = inp.config.matrix_gen_params.get("societal_bonuses", {})
 
         m0 = len(inp.r_i_assigned)
         if under_penalties is None:
@@ -113,7 +114,8 @@ def solve_subproblem_worker(args) -> Tuple[str, float, list, list, list, tuple |
             if i in priority:
                 sector_bonus *= bonus_factor
             bonus = sector_bonus * min(planned, produced)
-            obj += produced + bonus - under_cost - over_cost
+            societal_bonus = societal_bonuses.get(i, 0.0) * produced
+            obj += produced + bonus + societal_bonus - under_cost - over_cost
     pi_i = [0.5 for _ in inp.r_i_assigned]
     mu_iT_d_value = obj - sum(pi_i[j] * inp.r_i_assigned[j] for j in range(len(pi_i)))
     cut = make_opt_cut(inp.block_id, pi_i, mu_iT_d_value)

--- a/tests/test_master.py
+++ b/tests/test_master.py
@@ -25,3 +25,14 @@ def test_priority_sector_allocation():
     cuts = []
     r_vars, _ = solve_master_problem(blocks, m0, total_r, cuts, cfg)
     assert r_vars[0][0] > r_vars[1][0]
+
+
+def test_min_block_allocations():
+    cfg = BendersConfig(verbose=False, matrix_gen_params={"min_block_allocations": {0: 0.6}})
+    blocks = [("b0", 0, 1), ("b1", 1, 2)]
+    m0 = 1
+    total_r = np.array([10.0])
+    cuts = []
+    r_vars, _ = solve_master_problem(blocks, m0, total_r, cuts, cfg)
+    assert r_vars[0][0] >= 6.0
+    assert abs(r_vars[0][0] + r_vars[1][0] - 10.0) < 1e-9

--- a/tests/test_subproblem.py
+++ b/tests/test_subproblem.py
@@ -172,3 +172,23 @@ def test_production_bonus():
     cleanup_shared_memory()
 
     assert obj_bonus > obj_base
+
+
+def test_societal_bonus():
+    cfg_base = BendersConfig(verbose=False, matrix_gen_params={"planwirtschaft_objective": True})
+    cfg_bonus = BendersConfig(verbose=False, matrix_gen_params={"planwirtschaft_objective": True, "societal_bonuses": {0: 0.5}})
+    A = sp.identity(1, format="csr")
+    B = sp.csr_matrix([[1.0]])
+    A_meta = csr_to_shared("A", A)
+    B_meta = csr_to_shared("B", B)
+    args_base = ("b0", 0, 1, A_meta, B_meta, np.zeros(1), np.zeros(1), np.array([1.0]), cfg_base.__dict__)
+    _, obj_base, *_ = solve_subproblem_worker(args_base)
+    cleanup_shared_memory()
+
+    A_meta = csr_to_shared("A", A)
+    B_meta = csr_to_shared("B", B)
+    args_bonus = ("b0", 0, 1, A_meta, B_meta, np.zeros(1), np.zeros(1), np.array([1.0]), cfg_bonus.__dict__)
+    _, obj_bonus, *_ = solve_subproblem_worker(args_bonus)
+    cleanup_shared_memory()
+
+    assert obj_bonus > obj_base


### PR DESCRIPTION
## Summary
- support min block allocations in master problem
- integrate societal bonuses in subproblem objectives
- limit priority sector technology rows relative to other sectors
- expose new planwirtschaft parameters
- test min block allocations and societal bonuses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e4f7d130832fa8121aa263156808