### PR TITLE
Implement config loading and trade limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This repository contains a small Python implementation demonstrating the core st
 * **Adaptive Partitioning** – block sizes adjust according to the dual gap to better handle large planning models.
 * **Planned Economy Support** – generate matrices for `planwirtschaft` style input-output systems using the existing helpers.
 * **Hierarchical Priorities** – optional `priority_levels` and seasonal weights allow refined demand modeling with ecological penalties.
+* **Production and Trade Limits** – additional parameters bound individual production cells and import/export totals.
+* **Config Loading** – `PlanwirtschaftParams.from_file` and `BendersConfig.from_file` allow JSON based configuration files.
 
 The implementation is not intended for production use. It omits many optimizations and contains simplified placeholders.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,6 +20,9 @@ resources to these blocks. Component-wise penalties can be configured with
 
 New options include hierarchical priorities via `priority_levels`, seasonal
 scaling of demand with `seasonal_demand_weights` and ecological costs using
-`co2_penalties`. Parallel subproblem solving can be enabled with
-`use_parallel_subproblems` while `dynamic_block_weights` updates resource
-weights between iterations based on the previous production levels.
+`co2_penalties`. Production cell restrictions and trade limits can be set with
+`production_limits` and `import_export_limits`. Configuration files can be
+loaded through `PlanwirtschaftParams.from_file` or `BendersConfig.from_file`.
+Parallel subproblem solving can be enabled with `use_parallel_subproblems` while
+`dynamic_block_weights` updates resource weights between iterations using the
+previous distribution.

--- a/src/bendersx_engine/config.py
+++ b/src/bendersx_engine/config.py
@@ -38,9 +38,20 @@ class PlanwirtschaftParams:
     priority_levels: Dict[int, int] | None = None
     seasonal_demand_weights: List[float] | None = None
     co2_penalties: Dict[int, float] | None = None
+    production_limits: Dict[int, Dict[int, float]] | None = None
+    import_export_limits: Dict[int, Dict[str, float]] | None = None
 
     def to_dict(self) -> Dict:
         return {k: getattr(self, k) for k in self.__dataclass_fields__}
+
+    @staticmethod
+    def from_file(path: str) -> "PlanwirtschaftParams":
+        """Load parameters from a JSON file."""
+        import json
+
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return PlanwirtschaftParams(**data)
 
 
 @dataclass
@@ -92,3 +103,15 @@ class BendersConfig:
 
         if self.matrix_gen_params.get("priority_sectors") and self.priority_sector_allocation_factor < 1.0:
             raise ValueError("priority_sector_allocation_factor must be >= 1.0")
+
+    @staticmethod
+    def from_file(path: str) -> "BendersConfig":
+        """Load configuration from a JSON file."""
+        import json
+
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        params = data.get("matrix_gen_params")
+        if isinstance(params, dict):
+            data["matrix_gen_params"] = PlanwirtschaftParams(**params)
+        return BendersConfig(**data)

--- a/src/bendersx_engine/matrix_generation.py
+++ b/src/bendersx_engine/matrix_generation.py
@@ -139,6 +139,35 @@ def _apply_planwirtschaft_modifiers(A: SimpleMatrix, B: SimpleMatrix, params: di
                     factor = limit / row_sum
                     B.data[idx] = [val * factor for val in B.data[idx]]
 
+    prod_limits = params.get("production_limits")
+    if isinstance(prod_limits, dict):
+        for i, col_limits in prod_limits.items():
+            if 0 <= i < B.shape[0] and isinstance(col_limits, dict):
+                for j, limit in col_limits.items():
+                    if 0 <= j < B.shape[1] and limit >= 0:
+                        if B.data[i][j] > limit:
+                            B.data[i][j] = limit
+
+    trade_limits = params.get("import_export_limits")
+    if isinstance(trade_limits, dict):
+        import_lims = trade_limits.get("import")
+        export_lims = trade_limits.get("export")
+        if isinstance(import_lims, dict):
+            for j, lim in import_lims.items():
+                if 0 <= j < A.shape[1] and lim >= 0:
+                    col_sum = sum(A.data[i][j] for i in range(A.shape[0]))
+                    if col_sum > lim and col_sum > 0:
+                        factor = lim / col_sum
+                        for i in range(A.shape[0]):
+                            A.data[i][j] *= factor
+        if isinstance(export_lims, dict):
+            for i, lim in export_lims.items():
+                if 0 <= i < B.shape[0] and lim >= 0:
+                    row_sum = sum(B.data[i])
+                    if row_sum > lim and row_sum > 0:
+                        factor = lim / row_sum
+                        B.data[i] = [val * factor for val in B.data[i]]
+
 
 def _random_matrix(rows: int, cols: int, density: float) -> SimpleMatrix:
     data = []

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -12,3 +12,4 @@ def test_algorithm_runs():
     total_r = np.ones(m0)
     _, _, _, info = benders_decomposition(n, m0, total_r, A, B, cfg)
     assert info["iterations"] <= cfg.max_iterations_per_phase
+    assert isinstance(info.get("unfulfilled_demand"), list)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,28 @@
-from bendersx_engine import BendersConfig
+import json
+from bendersx_engine import BendersConfig, PlanwirtschaftParams
 
 
 def test_config_defaults():
     cfg = BendersConfig()
     assert cfg.highs_threads > 0
+
+
+def test_config_from_file(tmp_path):
+    data = {
+        "verbose": False,
+        "matrix_gen_params": {"diag_base": 0.3},
+    }
+    path = tmp_path / "cfg.json"
+    path.write_text(json.dumps(data))
+    cfg = BendersConfig.from_file(str(path))
+    assert cfg.verbose is False
+    assert cfg.matrix_gen_params["diag_base"] == 0.3
+
+
+def test_planwirtschaft_params_from_file(tmp_path):
+    data = {"diag_base": 0.4, "diag_variation": 0.5}
+    path = tmp_path / "params.json"
+    path.write_text(json.dumps(data))
+    params = PlanwirtschaftParams.from_file(str(path))
+    assert params.diag_base == 0.4
+    assert params.diag_variation == 0.5

--- a/tests/test_matrix_generation.py
+++ b/tests/test_matrix_generation.py
@@ -66,3 +66,17 @@ def test_priority_levels_and_seasonal_weights():
     cfg = BendersConfig(verbose=False, matrix_gen_params=params)
     _, B = generate_sparse_matrices(3, 1, problem_type="planwirtschaft", config=cfg)
     assert abs(B.data[0][0] - 1.2) < 1e-6
+
+
+def test_production_and_trade_limits():
+    params = PlanwirtschaftParams(
+        production_limits={0: {0: 0.2}},
+        import_export_limits={"import": {0: 0.1}, "export": {0: 0.3}},
+    )
+    cfg = BendersConfig(verbose=False, matrix_gen_params=params)
+    A, B = generate_sparse_matrices(2, 1, problem_type="planwirtschaft", config=cfg)
+    assert B.data[0][0] <= 0.2 + 1e-9
+    col_sum = sum(A.data[i][0] for i in range(2))
+    assert col_sum <= 0.1 + 1e-9
+    row_sum = sum(B.data[0])
+    assert row_sum <= 0.3 + 1e-9


### PR DESCRIPTION
## Summary
- support JSON-based parameter loading with `from_file`
- introduce production cell and trade limit parameters
- update docs and README for new options
- refine dynamic block weights and add demand shortfall stats
- test new configuration features and limits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e7eba8d0832f99e41bb2d6068530